### PR TITLE
Fixing Name/Link

### DIFF
--- a/integration-plugins/integration-plugins/available-plugins/README.md
+++ b/integration-plugins/integration-plugins/available-plugins/README.md
@@ -14,7 +14,7 @@ Below is a table of which plugins require which version of SonoranCAD to functio
 | [Check API ID](api-id-checker.md)                                              | Yes         | Yes         | Yes |
 | [Civilian Integration](civilian-integration.md)                                | **No**      | Yes         | Yes |
 | [Dispatch Notify](dispatch-notify.md)                                          | **No**      | Yes         | Yes |
-| [ESX/QBUS Support](framework-support-esx-qbcore-and-auto-fines/esx-support.md) | **Partial** | **Partial** | Yes |
+| [Framework Support](framework-support.md)                                      | **Partial** | **Partial** | Yes |
 | [Fire Siren](fire-siren.md)                                                    | **No**      | Yes         | Yes |
 | [FivePD](fivepd.md)                                                            | No          | Yes         | Yes |
 | [ForceReg](forcereg.md)                                                        | Yes         | Yes         | Yes |


### PR DESCRIPTION
Fixing name/link to go to the new/updated Framework Support plugin rather than the depreciated ESX Support plugin.